### PR TITLE
Typing useArgs

### DIFF
--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -424,17 +424,17 @@ export function useParameter<S>(parameterKey: string, defaultValue?: S): S | und
 }
 
 /* Returns current value of story args */
-export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: [string]) => void] {
+export function useArgs<SpecificArgs = Args>(): [SpecificArgs, (newArgs: SpecificArgs) => void, (argNames?: (keyof SpecificArgs)[]) => void] {
   const channel = addons.getChannel();
   const { id: storyId, args } = useStoryContext();
 
   const updateArgs = useCallback(
-    (updatedArgs: Args) => channel.emit(UPDATE_STORY_ARGS, { storyId, updatedArgs }),
+    (updatedArgs: SpecificArgs) => channel.emit(UPDATE_STORY_ARGS, { storyId, updatedArgs }),
     [channel, storyId]
   );
 
   const resetArgs = useCallback(
-    (argNames?: [string]) => channel.emit(RESET_STORY_ARGS, { storyId, argNames }),
+    (argNames?: (keyof SpecificArgs)[]) => channel.emit(RESET_STORY_ARGS, { storyId, argNames }),
     [channel, storyId]
   );
 


### PR DESCRIPTION
Issue:
useArgs is great, but it would be nice to type it so it can conform with my component props.

## What I did
- Typed useArgs with a generic, defaulting to the same behavior to be non-breaking.
- Also, resetArgs was typed with a tuple of `[string]` rather than being an array as it should be.